### PR TITLE
fix for category names with '/'

### DIFF
--- a/dstat_plot.rb
+++ b/dstat_plot.rb
@@ -23,7 +23,7 @@ def plot(dataSets, category, field, dry, target_dir)
       
       unless dry
         plot.terminal 'png size 1600,800 enhanced font "Helvetica,11"'
-        filename = "#{category}-#{field}.png"
+        filename = "#{category}-#{field}.png".sub("/", "_")
         plot.output filename
         puts "Saving plot to '#{target_dir}/#{filename}'"
       end


### PR DESCRIPTION
categories with "/" in them would cause an error in an attempt to save to file. "/" are now replaced with "_".
